### PR TITLE
fix(editing): add action to create new Vento file from "New" menu

### DIFF
--- a/src/main/kotlin/org/js/vento/plugin/actions/CreateVentoFileAction.kt
+++ b/src/main/kotlin/org/js/vento/plugin/actions/CreateVentoFileAction.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2025 Florian Hehlen & Óscar Otero
+ * All rights reserved.
+ */
+
+package org.js.vento.plugin.actions
+
+import com.intellij.ide.actions.CreateFileFromTemplateAction
+import com.intellij.ide.actions.CreateFileFromTemplateDialog
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiDirectory
+import org.js.vento.plugin.Vento
+
+/**
+ * Action to create a new Vento file from the "New" menu.
+ */
+class CreateVentoFileAction : CreateFileFromTemplateAction(
+    "Vento File",
+    "Create a new Vento template file",
+    Vento.ICON,
+) {
+    override fun buildDialog(project: Project, directory: PsiDirectory, builder: CreateFileFromTemplateDialog.Builder) {
+        builder
+            .setTitle("New Vento File")
+            .addKind("Vento file", Vento.ICON, "Vento File")
+    }
+
+    override fun getActionName(directory: PsiDirectory?, newName: String, templateName: String?): String = "Create Vento File: $newName"
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -61,5 +61,10 @@
             <keyboard-shortcut keymap="Mac OS X" first-keystroke="meta SLASH"/>
             <keyboard-shortcut keymap="Mac OS X 10.5+" first-keystroke="meta SLASH"/>
         </action>
+
+        <action id="Vento.CreateFile"
+                class="org.js.vento.plugin.actions.CreateVentoFileAction">
+            <add-to-group group-id="NewGroup" anchor="after" relative-to-action="NewGroup"/>
+        </action>
     </actions>
 </idea-plugin>

--- a/src/main/resources/fileTemplates/internal/Vento File.vto.ft
+++ b/src/main/resources/fileTemplates/internal/Vento File.vto.ft
@@ -1,0 +1,8 @@
+<html lang="en">
+    <head>
+        <title>Vento File</title>
+    </head>
+    <body>
+
+    </body>
+</html>


### PR DESCRIPTION
## Description
- Introduced `CreateVentoFileAction` to allow users to generate a new Vento template file via the "New" menu.
- Updated `plugin.xml` to register the new action with the `NewGroup`.
- Added a default Vento file template (`Vento File.vto.ft`) for streamlined file creation.

Please include a summary of the changes and the related issue. Explain the motivation behind these changes.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

closes: #178 