### PR TITLE
fix(editing): add refactoring support for Vento files

### DIFF
--- a/src/main/kotlin/org/js/vento/plugin/editor/RefactoringSupportProvider.kt
+++ b/src/main/kotlin/org/js/vento/plugin/editor/RefactoringSupportProvider.kt
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2025 Florian Hehlen & Óscar Otero
+ * All rights reserved.
+ */
+
+package org.js.vento.plugin.editor
+
+import com.intellij.lang.refactoring.RefactoringSupportProvider
+
+/**
+ * Provides refactoring support for Vento files, particularly for JavaScript code within script tags.
+ *
+ * This provider ensures that variable extraction and other refactoring operations work correctly
+ * in .vto files, similar to how they work in .html files.
+ */
+class RefactoringSupportProvider : RefactoringSupportProvider()

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -51,6 +51,7 @@
         <lang.braceMatcher language="Vento" implementationClass="org.js.vento.plugin.editor.VentoBraceMatcher"/>
         <lookup.charFilter implementation="org.js.vento.plugin.editor.VentoCharFilter"/>
         <lang.formatter language="Vento" implementationClass="org.js.vento.plugin.formatting.FormattingModelBuilder"/>
+        <lang.refactoringSupport language="Vento" implementationClass="org.js.vento.plugin.editor.RefactoringSupportProvider"/>
 
     </extensions>
 


### PR DESCRIPTION
## Description

- Introduced `RefactoringSupportProvider` to enable refactoring capabilities for `.vto` files.
- Registered the provider in `plugin.xml` to handle JavaScript refactoring inside script tags.
- Ensures seamless integration with IntelliJ's refactoring tools for improved developer experience.
- Does not work in `{{> ... }}` blocks, only works in <script> tags

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
